### PR TITLE
fix TestCase

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,11 +22,9 @@ class TestCase extends WebTestCase
 
     public function getEntityManager(): EntityManager
     {
-        $kernel = self::bootKernel();
-
         try {
             /** @var EntityManager|null $entityManager */
-            $entityManager = $kernel->getContainer()
+            $entityManager = self::getContainer()
                 ->get(EntityManager::class);
             if ($entityManager === null) {
                 throw new LogicException('You have requested a non-existent service #' . EntityManager::class . ' ');


### PR DESCRIPTION
prevent error App\Exception\LogicException: The "Doctrine\ORM\EntityManager" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.
